### PR TITLE
Master definition name transformer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,6 @@
 
 organization in ThisBuild := "com.iheart"
 
-resolvers +=  Resolver.bintrayRepo("scalaz", "releases")
-
-
 lazy val noPublishSettings = Seq(
   publish := (),
   publishLocal := (),

--- a/core/src/main/scala/com/iheart/playSwagger/CaseType.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/CaseType.scala
@@ -1,0 +1,25 @@
+package com.iheart.playSwagger
+
+sealed trait CaseType {
+  def transform(str: String): String
+}
+
+case object CamelCase extends CaseType {
+  override def transform(str: String) = {
+    (str.split("_").toList match {
+      case head :: tail ⇒ head :: tail.map(_.capitalize)
+      case x            ⇒ x
+    }).mkString
+  }
+}
+
+case object SnakeCase extends CaseType {
+  override def transform(str: String) = {
+    str.foldLeft(new StringBuilder) {
+      case (s, c) if Character.isUpperCase(c) ⇒
+        s.append("_").append(Character.toLowerCase(c))
+      case (s, c) ⇒
+        s.append(c)
+    }.toString
+  }
+}

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -8,7 +8,8 @@ import scala.reflect.runtime.universe._
 
 final case class DefinitionGenerator(
   modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-  mappings:       CustomMappings       = Nil)(implicit cl: ClassLoader) {
+  mappings:       CustomMappings       = Nil,
+  caseType:       CaseType             = CamelCase)(implicit cl: ClassLoader) {
 
   def dealiasParams(t: Type): Type = {
     appliedType(t.dealias.typeConstructor, t.typeArgs.map { arg ⇒
@@ -27,7 +28,7 @@ final case class DefinitionGenerator(
       val typeName = dealiasParams(field.typeSignature).toString
       // passing None for 'fixed' and 'default' here, since we're not dealing with route parameters
       val param = Parameter(name, typeName, None, None)
-      mapParam(param, modelQualifier, mappings)
+      mapParam(param, caseType, modelQualifier, mappings)
     }
 
     Definition(
@@ -74,7 +75,8 @@ final case class DefinitionGenerator(
 object DefinitionGenerator {
   def apply(
     domainNameSpace:             String,
-    customParameterTypeMappings: CustomMappings)(implicit cl: ClassLoader): DefinitionGenerator =
+    customParameterTypeMappings: CustomMappings,
+    caseType:                    CaseType)(implicit cl: ClassLoader): DefinitionGenerator =
     DefinitionGenerator(
-      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings)
+      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings, caseType)
 }

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -7,9 +7,9 @@ import play.routes.compiler.Parameter
 import scala.reflect.runtime.universe._
 
 final case class DefinitionGenerator(
-  modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-  mappings:       CustomMappings       = Nil,
-  caseType:       CaseType             = CamelCase)(implicit cl: ClassLoader) {
+  modelQualifier:  DomainModelQualifier       = PrefixDomainModelQualifier(),
+  mappings:        CustomMappings             = Nil,
+  nameTransformer: DefinitionNameTransformer  = NoTransformer)(implicit cl: ClassLoader) {
 
   def dealiasParams(t: Type): Type = {
     appliedType(t.dealias.typeConstructor, t.typeArgs.map { arg ⇒
@@ -28,7 +28,7 @@ final case class DefinitionGenerator(
       val typeName = dealiasParams(field.typeSignature).toString
       // passing None for 'fixed' and 'default' here, since we're not dealing with route parameters
       val param = Parameter(name, typeName, None, None)
-      mapParam(param, caseType, modelQualifier, mappings)
+      mapParam(param, nameTransformer, modelQualifier, mappings)
     }
 
     Definition(
@@ -76,7 +76,7 @@ object DefinitionGenerator {
   def apply(
     domainNameSpace:             String,
     customParameterTypeMappings: CustomMappings,
-    caseType:                    CaseType)(implicit cl: ClassLoader): DefinitionGenerator =
+    nameTransformer:             DefinitionNameTransformer)(implicit cl: ClassLoader): DefinitionGenerator =
     DefinitionGenerator(
-      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings, caseType)
+      PrefixDomainModelQualifier(domainNameSpace), customParameterTypeMappings, nameTransformer)
 }

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionGenerator.scala
@@ -7,9 +7,9 @@ import play.routes.compiler.Parameter
 import scala.reflect.runtime.universe._
 
 final case class DefinitionGenerator(
-  modelQualifier:  DomainModelQualifier       = PrefixDomainModelQualifier(),
-  mappings:        CustomMappings             = Nil,
-  nameTransformer: DefinitionNameTransformer  = NoTransformer)(implicit cl: ClassLoader) {
+  modelQualifier:  DomainModelQualifier      = PrefixDomainModelQualifier(),
+  mappings:        CustomMappings            = Nil,
+  nameTransformer: DefinitionNameTransformer = new NoTransformer)(implicit cl: ClassLoader) {
 
   def dealiasParams(t: Type): Type = {
     appliedType(t.dealias.typeConstructor, t.typeArgs.map { arg ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionNameTransformer.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionNameTransformer.scala
@@ -1,10 +1,14 @@
 package com.iheart.playSwagger
 
-sealed trait CaseType {
+trait DefinitionNameTransformer {
   def transform(str: String): String
 }
 
-case object CamelCase extends CaseType {
+case object NoTransformer extends DefinitionNameTransformer {
+  override def transform(str: String) = str
+}
+
+case object CamelcaseTransformer extends DefinitionNameTransformer {
   override def transform(str: String) = {
     (str.split("_").toList match {
       case head :: tail ⇒ head :: tail.map(_.capitalize)
@@ -13,7 +17,7 @@ case object CamelCase extends CaseType {
   }
 }
 
-case object SnakeCase extends CaseType {
+case object SnakecaseTransformer extends DefinitionNameTransformer {
   override def transform(str: String) = {
     str.foldLeft(new StringBuilder) {
       case (s, c) if Character.isUpperCase(c) ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionNameTransformer.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionNameTransformer.scala
@@ -4,11 +4,11 @@ trait DefinitionNameTransformer {
   def transform(str: String): String
 }
 
-case object NoTransformer extends DefinitionNameTransformer {
+final class NoTransformer extends DefinitionNameTransformer {
   override def transform(str: String) = str
 }
 
-case object CamelcaseTransformer extends DefinitionNameTransformer {
+final class CamelcaseTransformer extends DefinitionNameTransformer {
   override def transform(str: String) = {
     (str.split("_").toList match {
       case head :: tail ⇒ head :: tail.map(_.capitalize)
@@ -17,7 +17,7 @@ case object CamelcaseTransformer extends DefinitionNameTransformer {
   }
 }
 
-case object SnakecaseTransformer extends DefinitionNameTransformer {
+final class SnakecaseTransformer extends DefinitionNameTransformer {
   override def transform(str: String) = {
     str.foldLeft(new StringBuilder) {
       case (s, c) if Character.isUpperCase(c) ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/DefinitionNameTransformer.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/DefinitionNameTransformer.scala
@@ -7,23 +7,3 @@ trait DefinitionNameTransformer {
 final class NoTransformer extends DefinitionNameTransformer {
   override def transform(str: String) = str
 }
-
-final class CamelcaseTransformer extends DefinitionNameTransformer {
-  override def transform(str: String) = {
-    (str.split("_").toList match {
-      case head :: tail ⇒ head :: tail.map(_.capitalize)
-      case x            ⇒ x
-    }).mkString
-  }
-}
-
-final class SnakecaseTransformer extends DefinitionNameTransformer {
-  override def transform(str: String) = {
-    str.foldLeft(new StringBuilder) {
-      case (s, c) if Character.isUpperCase(c) ⇒
-        s.append("_").append(Character.toLowerCase(c))
-      case (s, c) ⇒
-        s.append(c)
-    }.toString
-  }
-}

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -12,10 +12,10 @@ object SwaggerParameterMapper {
   type MappingFunction = PartialFunction[String, SwaggerParameter]
 
   def mapParam(
-                parameter:       Parameter,
-                nameTransformer: DefinitionNameTransformer = CamelcaseTransformer,
-                modelQualifier:  DomainModelQualifier      = PrefixDomainModelQualifier(),
-                customMappings:  CustomMappings            = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
+    parameter:       Parameter,
+    nameTransformer: DefinitionNameTransformer = new NoTransformer,
+    modelQualifier:  DomainModelQualifier      = PrefixDomainModelQualifier(),
+    customMappings:  CustomMappings            = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
 
     def removeKnownPrefixes(name: String) = name.replaceAll("(scala.)|(java.lang.)|(math.)|(org.joda.time.)", "")
 

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -13,6 +13,7 @@ object SwaggerParameterMapper {
 
   def mapParam(
     parameter:      Parameter,
+    caseType:       CaseType             = CamelCase,
     modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
     customMappings: CustomMappings       = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
 
@@ -51,7 +52,7 @@ object SwaggerParameterMapper {
       format: Option[String]      = None,
       enum:   Option[Seq[String]] = None) =
       GenSwaggerParameter(
-        parameter.name,
+        caseType.transform(parameter.name),
         `type` = Some(tp),
         format = format,
         required = defaultValueO.isEmpty,
@@ -69,7 +70,7 @@ object SwaggerParameterMapper {
       GenSwaggerParameter(parameter.name, referenceType = Some(referenceType))
 
     def optionalParam(optionalTpe: String) = {
-      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), modelQualifier = modelQualifier, customMappings = customMappings)
+      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), caseType, modelQualifier = modelQualifier, customMappings = customMappings)
       asRequired.update(required = false, default = asRequired.default)
     }
 
@@ -105,7 +106,7 @@ object SwaggerParameterMapper {
         // http://stackoverflow.com/questions/26206685/how-can-i-describe-complex-json-model-in-swagger
         updateGenParam(generalParamMF("array"))(_.copy(
           items = Some(
-            mapParam(parameter.copy(typeName = collectionItemType(tpe).get), modelQualifier, customMappings))))
+            mapParam(parameter.copy(typeName = collectionItemType(tpe).get), caseType, modelQualifier, customMappings))))
     }
 
     val customMappingMF: MappingFunction = customMappings.map { mapping ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -52,7 +52,7 @@ object SwaggerParameterMapper {
       format: Option[String]      = None,
       enum:   Option[Seq[String]] = None) =
       GenSwaggerParameter(
-        nameTransformer.transform(parameter.name),
+        name = nameTransformer.transform(parameter.name),
         `type` = Some(tp),
         format = format,
         required = defaultValueO.isEmpty,

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerParameterMapper.scala
@@ -12,10 +12,10 @@ object SwaggerParameterMapper {
   type MappingFunction = PartialFunction[String, SwaggerParameter]
 
   def mapParam(
-    parameter:      Parameter,
-    caseType:       CaseType             = CamelCase,
-    modelQualifier: DomainModelQualifier = PrefixDomainModelQualifier(),
-    customMappings: CustomMappings       = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
+                parameter:       Parameter,
+                nameTransformer: DefinitionNameTransformer = CamelcaseTransformer,
+                modelQualifier:  DomainModelQualifier      = PrefixDomainModelQualifier(),
+                customMappings:  CustomMappings            = Nil)(implicit cl: ClassLoader): SwaggerParameter = {
 
     def removeKnownPrefixes(name: String) = name.replaceAll("(scala.)|(java.lang.)|(math.)|(org.joda.time.)", "")
 
@@ -52,7 +52,7 @@ object SwaggerParameterMapper {
       format: Option[String]      = None,
       enum:   Option[Seq[String]] = None) =
       GenSwaggerParameter(
-        caseType.transform(parameter.name),
+        nameTransformer.transform(parameter.name),
         `type` = Some(tp),
         format = format,
         required = defaultValueO.isEmpty,
@@ -70,7 +70,7 @@ object SwaggerParameterMapper {
       GenSwaggerParameter(parameter.name, referenceType = Some(referenceType))
 
     def optionalParam(optionalTpe: String) = {
-      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), caseType, modelQualifier = modelQualifier, customMappings = customMappings)
+      val asRequired = mapParam(parameter.copy(typeName = optionalTpe), nameTransformer, modelQualifier = modelQualifier, customMappings = customMappings)
       asRequired.update(required = false, default = asRequired.default)
     }
 
@@ -106,7 +106,7 @@ object SwaggerParameterMapper {
         // http://stackoverflow.com/questions/26206685/how-can-i-describe-complex-json-model-in-swagger
         updateGenParam(generalParamMF("array"))(_.copy(
           items = Some(
-            mapParam(parameter.copy(typeName = collectionItemType(tpe).get), caseType, modelQualifier, customMappings))))
+            mapParam(parameter.copy(typeName = collectionItemType(tpe).get), nameTransformer, modelQualifier, customMappings))))
     }
 
     val customMappingMF: MappingFunction = customMappings.map { mapping ⇒

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -17,28 +17,28 @@ object SwaggerSpecGenerator {
   private val marker = "##"
   val customMappingsFileName = "swagger-custom-mappings"
   val baseSpecFileName = "swagger"
-  def apply(caseType: CaseType, swaggerV3: Boolean, domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), caseType, swaggerV3 = swaggerV3)
+  def apply(nameTransformer: DefinitionNameTransformer, swaggerV3: Boolean, domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
+    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), nameTransformer, swaggerV3 = swaggerV3)
   }
   def apply(swaggerV3: Boolean, domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), CamelCase, swaggerV3 = swaggerV3)
+    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), CamelcaseTransformer, swaggerV3 = swaggerV3)
   }
-  def apply(caseType: CaseType, outputTransformers: Seq[OutputTransformer], domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), caseType, outputTransformers = outputTransformers)
+  def apply(nameTransformer: DefinitionNameTransformer, outputTransformers: Seq[OutputTransformer], domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
+    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), nameTransformer, outputTransformers = outputTransformers)
   }
   def apply(outputTransformers: Seq[OutputTransformer], domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), CamelCase, outputTransformers = outputTransformers)
+    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), CamelcaseTransformer, outputTransformers = outputTransformers)
   }
 
   case object MissingBaseSpecException extends Exception(s"Missing a $baseSpecFileName.yml or $baseSpecFileName.json to provide base swagger spec")
 }
 
 final case class SwaggerSpecGenerator(
-  modelQualifier:        DomainModelQualifier   = PrefixDomainModelQualifier(),
-  caseType:              CaseType               = CamelCase,
-  defaultPostBodyFormat: String                 = "application/json",
-  outputTransformers:    Seq[OutputTransformer] = Nil,
-  swaggerV3:             Boolean                = false)(implicit cl: ClassLoader) {
+                                       modelQualifier:        DomainModelQualifier      = PrefixDomainModelQualifier(),
+                                       nameTransformer:       DefinitionNameTransformer = CamelcaseTransformer,
+                                       defaultPostBodyFormat: String                    = "application/json",
+                                       outputTransformers:    Seq[OutputTransformer]    = Nil,
+                                       swaggerV3:             Boolean                   = false)(implicit cl: ClassLoader) {
   import SwaggerSpecGenerator.{ customMappingsFileName, baseSpecFileName, MissingBaseSpecException }
   // routes with their prefix
   type Routes = (String, Seq[Route])
@@ -149,7 +149,7 @@ final case class SwaggerSpecGenerator(
         if modelQualifier.isModel(className)
       } yield className
 
-      DefinitionGenerator(modelQualifier, customMappings, caseType).allDefinitions(referredClasses)
+      DefinitionGenerator(modelQualifier, customMappings, nameTransformer).allDefinitions(referredClasses)
     }
 
     val definitionsJson = JsObject(definitions.map(d ⇒ d.name → Json.toJson(d)))
@@ -368,7 +368,7 @@ final case class SwaggerSpecGenerator(
         paramList ← route.call.parameters.toSeq
         param ← paramList
         if param.fixed.isEmpty // Removes parameters the client cannot set
-      } yield mapParam(param, caseType, modelQualifier, customMappings)
+      } yield mapParam(param, nameTransformer, modelQualifier, customMappings)
 
       JsArray(params.flatMap { p ⇒
         val jos: List[JsObject] = p match {

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecGenerator.scala
@@ -21,24 +21,24 @@ object SwaggerSpecGenerator {
     SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), nameTransformer, swaggerV3 = swaggerV3)
   }
   def apply(swaggerV3: Boolean, domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), CamelcaseTransformer, swaggerV3 = swaggerV3)
+    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), new NoTransformer, swaggerV3 = swaggerV3)
   }
   def apply(nameTransformer: DefinitionNameTransformer, outputTransformers: Seq[OutputTransformer], domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
     SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), nameTransformer, outputTransformers = outputTransformers)
   }
   def apply(outputTransformers: Seq[OutputTransformer], domainNameSpaces: String*)(implicit cl: ClassLoader): SwaggerSpecGenerator = {
-    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), CamelcaseTransformer, outputTransformers = outputTransformers)
+    SwaggerSpecGenerator(PrefixDomainModelQualifier(domainNameSpaces: _*), new NoTransformer, outputTransformers = outputTransformers)
   }
 
   case object MissingBaseSpecException extends Exception(s"Missing a $baseSpecFileName.yml or $baseSpecFileName.json to provide base swagger spec")
 }
 
 final case class SwaggerSpecGenerator(
-                                       modelQualifier:        DomainModelQualifier      = PrefixDomainModelQualifier(),
-                                       nameTransformer:       DefinitionNameTransformer = CamelcaseTransformer,
-                                       defaultPostBodyFormat: String                    = "application/json",
-                                       outputTransformers:    Seq[OutputTransformer]    = Nil,
-                                       swaggerV3:             Boolean                   = false)(implicit cl: ClassLoader) {
+  modelQualifier:        DomainModelQualifier      = PrefixDomainModelQualifier(),
+  nameTransformer:       DefinitionNameTransformer = new NoTransformer,
+  defaultPostBodyFormat: String                    = "application/json",
+  outputTransformers:    Seq[OutputTransformer]    = Nil,
+  swaggerV3:             Boolean                   = false)(implicit cl: ClassLoader) {
   import SwaggerSpecGenerator.{ customMappingsFileName, baseSpecFileName, MissingBaseSpecException }
   // routes with their prefix
   type Routes = (String, Seq[Route])

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -22,9 +22,9 @@ object SwaggerSpecRunner extends App {
       }
     }
     val caseType = swaggerDefinitionsCaseType match {
-      case "camelCase"  ⇒ CamelCase
-      case "snakeCases" ⇒ SnakeCase
-      case _            ⇒ CamelCase
+      case "camelCase"  ⇒ CamelcaseTransformer
+      case "snakeCases" ⇒ SnakecaseTransformer
+      case _            ⇒ NoTransformer
     }
 
     SwaggerSpecGenerator(

--- a/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
+++ b/core/src/main/scala/com/iheart/playSwagger/SwaggerSpecRunner.scala
@@ -2,12 +2,12 @@ package com.iheart.playSwagger
 
 import java.nio.file.{ Files, Paths, StandardOpenOption }
 
-import scala.util.{ Success, Failure, Try }
+import scala.util.{ Failure, Success, Try }
 
 object SwaggerSpecRunner extends App {
   implicit def cl = getClass.getClassLoader
 
-  val (targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: Nil) = args.toList
+  val (targetFile :: routesFile :: domainNameSpaceArgs :: outputTransformersArgs :: swaggerV3String :: swaggerDefinitionsCaseType :: Nil) = args.toList
   private def fileArg = Paths.get(targetFile)
   private def swaggerJson = {
     val swaggerV3 = java.lang.Boolean.parseBoolean(swaggerV3String)
@@ -21,8 +21,15 @@ object SwaggerSpecRunner extends App {
         case Success(el) ⇒ el
       }
     }
+    val caseType = swaggerDefinitionsCaseType match {
+      case "camelCase"  ⇒ CamelCase
+      case "snakeCases" ⇒ SnakeCase
+      case _            ⇒ CamelCase
+    }
+
     SwaggerSpecGenerator(
       domainModelQualifier,
+      caseType,
       outputTransformers = transformers,
       swaggerV3 = swaggerV3).generate(routesFile).get.toString
   }

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -56,7 +56,7 @@ class DefinitionGeneratorSpec extends Specification {
 
     "generate properties" >> {
 
-      val result = DefinitionGenerator("com.iheart.playSwagger", Nil, CamelCase).definition[Foo].properties
+      val result = DefinitionGenerator("com.iheart.playSwagger", Nil, NoTransformer).definition[Foo].properties
 
       result.length === 7
 
@@ -89,12 +89,12 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "read class in Object" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
+      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
       result.properties.head.name === "bar"
     }
 
     "read alias type in Object" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
+      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
 
       val last = result.properties.last.asInstanceOf[GenSwaggerParameter]
       last.name === "id"
@@ -103,24 +103,24 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "read sequence items" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.FooWithSeq")
+      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.FooWithSeq")
       result.properties.head.asInstanceOf[GenSwaggerParameter].items.get.asInstanceOf[GenSwaggerParameter].referenceType === Some("com.iheart.playSwagger.SeqItem")
     }
 
     "read primitive sequence items" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.WithListOfPrimitive")
+      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.WithListOfPrimitive")
       result.properties.head.asInstanceOf[GenSwaggerParameter].items.get.asInstanceOf[GenSwaggerParameter].`type` === Some("integer")
 
     }
 
     "read Optional items " >> {
-      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.FooWithOption")
+      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.FooWithOption")
       result.properties.head.asInstanceOf[GenSwaggerParameter].referenceType must beSome("com.iheart.playSwagger.OptionItem")
     }
 
     "with dates" >> {
       "no override" >> {
-        val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.WithDate")
+        val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[GenSwaggerParameter]
         prop.`type` must beSome("integer")
         prop.format must beSome("epoch")
@@ -132,7 +132,7 @@ class DefinitionGeneratorSpec extends Specification {
           CustomTypeMapping(
             `type` = "org.joda.time.DateTime",
             specAsParameter = customJson))
-        val result = DefinitionGenerator("com.iheart", mappings, CamelCase).definition("com.iheart.playSwagger.WithDate")
+        val result = DefinitionGenerator("com.iheart", mappings, NoTransformer).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[CustomSwaggerParameter]
         prop.specAsParameter === customJson
       }
@@ -143,7 +143,7 @@ class DefinitionGeneratorSpec extends Specification {
       val customMapping = CustomTypeMapping(
         `type` = "com.iheart.playSwagger.WrappedString",
         specAsParameter = customJson)
-      val generator = DefinitionGenerator("com.iheart", List(customMapping), CamelCase)
+      val generator = DefinitionGenerator("com.iheart", List(customMapping), NoTransformer)
       val definition = generator.definition[FooWithWrappedStringProperties]
 
       "support simple property types" >> {

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -56,7 +56,7 @@ class DefinitionGeneratorSpec extends Specification {
 
     "generate properties" >> {
 
-      val result = DefinitionGenerator("com.iheart.playSwagger", Nil).definition[Foo].properties
+      val result = DefinitionGenerator("com.iheart.playSwagger", Nil, CamelCase).definition[Foo].properties
 
       result.length === 7
 
@@ -89,12 +89,12 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "read class in Object" >> {
-      val result = DefinitionGenerator("com.iheart", Nil).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
+      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
       result.properties.head.name === "bar"
     }
 
     "read alias type in Object" >> {
-      val result = DefinitionGenerator("com.iheart", Nil).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
+      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
 
       val last = result.properties.last.asInstanceOf[GenSwaggerParameter]
       last.name === "id"
@@ -103,24 +103,24 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "read sequence items" >> {
-      val result = DefinitionGenerator("com.iheart", Nil).definition("com.iheart.playSwagger.FooWithSeq")
+      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.FooWithSeq")
       result.properties.head.asInstanceOf[GenSwaggerParameter].items.get.asInstanceOf[GenSwaggerParameter].referenceType === Some("com.iheart.playSwagger.SeqItem")
     }
 
     "read primitive sequence items" >> {
-      val result = DefinitionGenerator("com.iheart", Nil).definition("com.iheart.playSwagger.WithListOfPrimitive")
+      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.WithListOfPrimitive")
       result.properties.head.asInstanceOf[GenSwaggerParameter].items.get.asInstanceOf[GenSwaggerParameter].`type` === Some("integer")
 
     }
 
     "read Optional items " >> {
-      val result = DefinitionGenerator("com.iheart", Nil).definition("com.iheart.playSwagger.FooWithOption")
+      val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.FooWithOption")
       result.properties.head.asInstanceOf[GenSwaggerParameter].referenceType must beSome("com.iheart.playSwagger.OptionItem")
     }
 
     "with dates" >> {
       "no override" >> {
-        val result = DefinitionGenerator("com.iheart", Nil).definition("com.iheart.playSwagger.WithDate")
+        val result = DefinitionGenerator("com.iheart", Nil, CamelCase).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[GenSwaggerParameter]
         prop.`type` must beSome("integer")
         prop.format must beSome("epoch")
@@ -132,7 +132,7 @@ class DefinitionGeneratorSpec extends Specification {
           CustomTypeMapping(
             `type` = "org.joda.time.DateTime",
             specAsParameter = customJson))
-        val result = DefinitionGenerator("com.iheart", mappings).definition("com.iheart.playSwagger.WithDate")
+        val result = DefinitionGenerator("com.iheart", mappings, CamelCase).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[CustomSwaggerParameter]
         prop.specAsParameter === customJson
       }
@@ -143,7 +143,7 @@ class DefinitionGeneratorSpec extends Specification {
       val customMapping = CustomTypeMapping(
         `type` = "com.iheart.playSwagger.WrappedString",
         specAsParameter = customJson)
-      val generator = DefinitionGenerator("com.iheart", List(customMapping))
+      val generator = DefinitionGenerator("com.iheart", List(customMapping), CamelCase)
       val definition = generator.definition[FooWithWrappedStringProperties]
 
       "support simple property types" >> {

--- a/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/DefinitionGeneratorSpec.scala
@@ -56,7 +56,7 @@ class DefinitionGeneratorSpec extends Specification {
 
     "generate properties" >> {
 
-      val result = DefinitionGenerator("com.iheart.playSwagger", Nil, NoTransformer).definition[Foo].properties
+      val result = DefinitionGenerator("com.iheart.playSwagger", Nil, new NoTransformer).definition[Foo].properties
 
       result.length === 7
 
@@ -89,12 +89,12 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "read class in Object" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
+      val result = DefinitionGenerator("com.iheart", Nil, new NoTransformer).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
       result.properties.head.name === "bar"
     }
 
     "read alias type in Object" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
+      val result = DefinitionGenerator("com.iheart", Nil, new NoTransformer).definition("com.iheart.playSwagger.MyObject.MyInnerClass")
 
       val last = result.properties.last.asInstanceOf[GenSwaggerParameter]
       last.name === "id"
@@ -103,24 +103,24 @@ class DefinitionGeneratorSpec extends Specification {
     }
 
     "read sequence items" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.FooWithSeq")
+      val result = DefinitionGenerator("com.iheart", Nil, new NoTransformer).definition("com.iheart.playSwagger.FooWithSeq")
       result.properties.head.asInstanceOf[GenSwaggerParameter].items.get.asInstanceOf[GenSwaggerParameter].referenceType === Some("com.iheart.playSwagger.SeqItem")
     }
 
     "read primitive sequence items" >> {
-      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.WithListOfPrimitive")
+      val result = DefinitionGenerator("com.iheart", Nil, new NoTransformer).definition("com.iheart.playSwagger.WithListOfPrimitive")
       result.properties.head.asInstanceOf[GenSwaggerParameter].items.get.asInstanceOf[GenSwaggerParameter].`type` === Some("integer")
 
     }
 
     "read Optional items " >> {
-      val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.FooWithOption")
+      val result = DefinitionGenerator("com.iheart", Nil, new NoTransformer).definition("com.iheart.playSwagger.FooWithOption")
       result.properties.head.asInstanceOf[GenSwaggerParameter].referenceType must beSome("com.iheart.playSwagger.OptionItem")
     }
 
     "with dates" >> {
       "no override" >> {
-        val result = DefinitionGenerator("com.iheart", Nil, NoTransformer).definition("com.iheart.playSwagger.WithDate")
+        val result = DefinitionGenerator("com.iheart", Nil, new NoTransformer).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[GenSwaggerParameter]
         prop.`type` must beSome("integer")
         prop.format must beSome("epoch")
@@ -132,7 +132,7 @@ class DefinitionGeneratorSpec extends Specification {
           CustomTypeMapping(
             `type` = "org.joda.time.DateTime",
             specAsParameter = customJson))
-        val result = DefinitionGenerator("com.iheart", mappings, NoTransformer).definition("com.iheart.playSwagger.WithDate")
+        val result = DefinitionGenerator("com.iheart", mappings, new NoTransformer).definition("com.iheart.playSwagger.WithDate")
         val prop = result.properties.head.asInstanceOf[CustomSwaggerParameter]
         prop.specAsParameter === customJson
       }
@@ -143,7 +143,7 @@ class DefinitionGeneratorSpec extends Specification {
       val customMapping = CustomTypeMapping(
         `type` = "com.iheart.playSwagger.WrappedString",
         specAsParameter = customJson)
-      val generator = DefinitionGenerator("com.iheart", List(customMapping), NoTransformer)
+      val generator = DefinitionGenerator("com.iheart", List(customMapping), new NoTransformer)
       val definition = generator.definition[FooWithWrappedStringProperties]
 
       "support simple property types" >> {

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -129,25 +129,25 @@ class SwaggerParameterMapperSpec extends Specification {
         default = Option(JsString("defaultValue")))
     }
     "map definition name to Camelcase" >> {
-      mapParam(Parameter("fieldWithAny", "Any", None, None), CamelcaseTransformer) === GenSwaggerParameter(
+      mapParam(Parameter("fieldWithAny", "Any", None, None), new CamelcaseTransformer) === GenSwaggerParameter(
         name = "fieldWithAny",
         `type` = Option("any"),
         example = Option(JsString("any JSON value")))
     }
     "map definition name to Snakecase" >> {
-      mapParam(Parameter("fieldWithAny", "Any", None, None), SnakecaseTransformer) === GenSwaggerParameter(
+      mapParam(Parameter("fieldWithAny", "Any", None, None), new SnakecaseTransformer) === GenSwaggerParameter(
         name = "field_with_any",
         `type` = Option("any"),
         example = Option(JsString("any JSON value")))
     }
     "map definition name to as it is" >> {
-      mapParam(Parameter("field_WithAny", "Any", None, None), NoTransformer) === GenSwaggerParameter(
+      mapParam(Parameter("field_WithAny", "Any", None, None), new NoTransformer) === GenSwaggerParameter(
         name = "field_WithAny",
         `type` = Option("any"),
         example = Option(JsString("any JSON value")))
     }
     "Snakecase not equal to Camelcase" >> {
-      val param = mapParam(Parameter("fieldWithAny", "Any", None, None), SnakecaseTransformer)
+      val param = mapParam(Parameter("fieldWithAny", "Any", None, None), new SnakecaseTransformer)
       param.name !== "fieldWithAny"
     }
   }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -128,27 +128,11 @@ class SwaggerParameterMapperSpec extends Specification {
         required = false,
         default = Option(JsString("defaultValue")))
     }
-    "map definition name to Camelcase" >> {
-      mapParam(Parameter("fieldWithAny", "Any", None, None), new CamelcaseTransformer) === GenSwaggerParameter(
-        name = "fieldWithAny",
-        `type` = Option("any"),
-        example = Option(JsString("any JSON value")))
-    }
-    "map definition name to Snakecase" >> {
-      mapParam(Parameter("fieldWithAny", "Any", None, None), new SnakecaseTransformer) === GenSwaggerParameter(
-        name = "field_with_any",
-        `type` = Option("any"),
-        example = Option(JsString("any JSON value")))
-    }
     "map definition name to as it is" >> {
       mapParam(Parameter("field_WithAny", "Any", None, None), new NoTransformer) === GenSwaggerParameter(
         name = "field_WithAny",
         `type` = Option("any"),
         example = Option(JsString("any JSON value")))
-    }
-    "Snakecase not equal to Camelcase" >> {
-      val param = mapParam(Parameter("fieldWithAny", "Any", None, None), new SnakecaseTransformer)
-      param.name !== "fieldWithAny"
     }
   }
 }

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -128,6 +128,22 @@ class SwaggerParameterMapperSpec extends Specification {
         required = false,
         default = Option(JsString("defaultValue")))
     }
+    "map definition name to Camel Case type" >> {
+      mapParam(Parameter("fieldWithAny", "Any", None, None), CamelCase) === GenSwaggerParameter(
+        name = "fieldWithAny",
+        `type` = Option("any"),
+        example = Option(JsString("any JSON value")))
+    }
+    "map definition name to Snake Case type" >> {
+      mapParam(Parameter("fieldWithAny", "Any", None, None), SnakeCase) === GenSwaggerParameter(
+        name = "field_with_any",
+        `type` = Option("any"),
+        example = Option(JsString("any JSON value")))
+    }
+    "map definition name to Snake Case type not to Camel case" >> {
+      val param = mapParam(Parameter("fieldWithAny", "Any", None, None), SnakeCase)
+      param.name !== "fieldWithAny"
+    }
   }
 }
 

--- a/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
+++ b/core/src/test/scala/com/iheart/playSwagger/SwaggerParameterMapperSpec.scala
@@ -128,20 +128,26 @@ class SwaggerParameterMapperSpec extends Specification {
         required = false,
         default = Option(JsString("defaultValue")))
     }
-    "map definition name to Camel Case type" >> {
-      mapParam(Parameter("fieldWithAny", "Any", None, None), CamelCase) === GenSwaggerParameter(
+    "map definition name to Camelcase" >> {
+      mapParam(Parameter("fieldWithAny", "Any", None, None), CamelcaseTransformer) === GenSwaggerParameter(
         name = "fieldWithAny",
         `type` = Option("any"),
         example = Option(JsString("any JSON value")))
     }
-    "map definition name to Snake Case type" >> {
-      mapParam(Parameter("fieldWithAny", "Any", None, None), SnakeCase) === GenSwaggerParameter(
+    "map definition name to Snakecase" >> {
+      mapParam(Parameter("fieldWithAny", "Any", None, None), SnakecaseTransformer) === GenSwaggerParameter(
         name = "field_with_any",
         `type` = Option("any"),
         example = Option(JsString("any JSON value")))
     }
-    "map definition name to Snake Case type not to Camel case" >> {
-      val param = mapParam(Parameter("fieldWithAny", "Any", None, None), SnakeCase)
+    "map definition name to as it is" >> {
+      mapParam(Parameter("field_WithAny", "Any", None, None), NoTransformer) === GenSwaggerParameter(
+        name = "field_WithAny",
+        `type` = Option("any"),
+        example = Option(JsString("any JSON value")))
+    }
+    "Snakecase not equal to Camelcase" >> {
+      val param = mapParam(Parameter("fieldWithAny", "Any", None, None), SnakecaseTransformer)
       param.name !== "fieldWithAny"
     }
   }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -13,5 +13,5 @@ trait SwaggerKeys {
   val swaggerOutputTransformers = SettingKey[Seq[String]]("swaggerOutputTransformers", "list of output transformers for processing swagger file")
   val swaggerV3 = SettingKey[Boolean]("swaggerV3", "whether to to produce output compatible with Swagger 3 (also knwon as OpenAPI 3)")
   val envOutputTransformer = "com.iheart.playSwagger.EnvironmentVariablesTransformer"
-  val swaggerDefinitionsCaseType = SettingKey[String]("swaggerDefinitionsCaseType", "the case type for swagger definitions")
+  val swaggerDefinitionNameTransformer = SettingKey[String]("swaggerDefinitionNameTransformer", "swagger definitions name transformer")
 }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerKeys.scala
@@ -13,4 +13,5 @@ trait SwaggerKeys {
   val swaggerOutputTransformers = SettingKey[Seq[String]]("swaggerOutputTransformers", "list of output transformers for processing swagger file")
   val swaggerV3 = SettingKey[Boolean]("swaggerV3", "whether to to produce output compatible with Swagger 3 (also knwon as OpenAPI 3)")
   val envOutputTransformer = "com.iheart.playSwagger.EnvironmentVariablesTransformer"
+  val swaggerDefinitionsCaseType = SettingKey[String]("swaggerDefinitionsCaseType", "the case type for swagger definitions")
 }

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -27,7 +27,7 @@ object SwaggerPlugin extends AutoPlugin {
     //todo: remove hardcoded org name using BuildInfo
     libraryDependencies += "com.iheart" %% "play-swagger" % playSwaggerVersion % swaggerConfig,
     swaggerDomainNameSpaces := Seq(),
-    swaggerDefinitionNameTransformer := "com.iheart.playSwagger.DefinitionNameTransformer",
+    swaggerDefinitionNameTransformer := "com.iheart.playSwagger.NoTransformer",
     swaggerV3 := false,
     swaggerTarget := target.value / "swagger",
     swaggerFileName := "swagger.json",

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -27,7 +27,7 @@ object SwaggerPlugin extends AutoPlugin {
     //todo: remove hardcoded org name using BuildInfo
     libraryDependencies += "com.iheart" %% "play-swagger" % playSwaggerVersion % swaggerConfig,
     swaggerDomainNameSpaces := Seq(),
-    swaggerDefinitionsCaseType := "camelCase",
+    swaggerDefinitionNameTransformer := "com.iheart.playSwagger.DefinitionNameTransformer",
     swaggerV3 := false,
     swaggerTarget := target.value / "swagger",
     swaggerFileName := "swagger.json",
@@ -41,7 +41,7 @@ object SwaggerPlugin extends AutoPlugin {
         swaggerDomainNameSpaces.value.mkString(",") ::
         swaggerOutputTransformers.value.mkString(",") ::
         swaggerV3.value.toString ::
-        swaggerDefinitionsCaseType.value ::
+        swaggerDefinitionNameTransformer.value ::
         Nil
       val swaggerClasspath = data((fullClasspath in Runtime).value) ++ update.value.select(configurationFilter(swaggerConfig.name))
       toError(runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log))

--- a/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
+++ b/sbtPlugin/src/main/scala/com/iheart/sbtPlaySwagger/SwaggerPlugin.scala
@@ -27,6 +27,7 @@ object SwaggerPlugin extends AutoPlugin {
     //todo: remove hardcoded org name using BuildInfo
     libraryDependencies += "com.iheart" %% "play-swagger" % playSwaggerVersion % swaggerConfig,
     swaggerDomainNameSpaces := Seq(),
+    swaggerDefinitionsCaseType := "camelCase",
     swaggerV3 := false,
     swaggerTarget := target.value / "swagger",
     swaggerFileName := "swagger.json",
@@ -40,6 +41,7 @@ object SwaggerPlugin extends AutoPlugin {
         swaggerDomainNameSpaces.value.mkString(",") ::
         swaggerOutputTransformers.value.mkString(",") ::
         swaggerV3.value.toString ::
+        swaggerDefinitionsCaseType.value ::
         Nil
       val swaggerClasspath = data((fullClasspath in Runtime).value) ++ update.value.select(configurationFilter(swaggerConfig.name))
       toError(runner.value.run("com.iheart.playSwagger.SwaggerSpecRunner", swaggerClasspath, args, streams.value.log))


### PR DESCRIPTION
If you have model  

> case class Order(currencyId: String)

 now swagger plugin generate definition:
```
models.Order": {
      "properties": {
        "currencyId": {
          "type": "string"
        }
  }
```
But if you want you definition in snake case, you should change you model to

>  case class Order(currency_id: String)

And only after that you get snake case definition.

This pull request allows user to define definition name transformer: camel case, snake case or any other, without changing model.